### PR TITLE
add allowed mentions

### DIFF
--- a/CSharpDiscordWebhook.NET/Discord/Classes.cs
+++ b/CSharpDiscordWebhook.NET/Discord/Classes.cs
@@ -41,6 +41,13 @@ public class DiscordMessage
     /// List of embeds
     /// </summary>
     public List<DiscordEmbed> Embeds { get; set; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("allowed_mentions")]
+    /// <summary>
+    /// Allowed mentions for this message
+    /// </summary>
+    public AllowedMentions AllowedMentions { get; set; }
 }
 
 public class DiscordEmbed
@@ -271,4 +278,25 @@ public class EmbedField
     /// Field align
     /// </summary>
     public bool? InLine { get; set; }
+}
+
+public class AllowedMentions
+{
+    [JsonPropertyName("parse")]
+    /// <summary>
+    /// List of allowd mention types to parse from the content
+    /// </summary>
+    public List<string> Parse { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("roles")]
+    /// <summary>
+    /// List of role_ids to mention
+    /// </summary>
+    public List<string> Roles { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("users")]
+    /// <summary>
+    /// List of user_ids to mention
+    /// </summary>
+    public List<string> Users { get; set; }
 }

--- a/WebhookTest/Program.cs
+++ b/WebhookTest/Program.cs
@@ -34,6 +34,7 @@ namespace WebhookTest
             await dn.TestFileAsync();
             await dn.TestEmbedAsync();
             await dn.TestErrorAsync();
+            await dn.TestAllowedMentionsAsync();
 
             Console.WriteLine("\n\nFinished. Press any key to exit...");
             Console.ReadKey();
@@ -181,6 +182,16 @@ namespace WebhookTest
             {
                 Console.WriteLine($"Server response: {ex.Message}");
             }
+        }
+
+        public async Task TestAllowedMentionsAsync()
+        {
+            Console.WriteLine("Testing allowed mentions...");
+            
+            DiscordMessage msg = new DiscordMessage();
+            msg.Content = "This should not notify @everyone";
+            msg.AllowedMentions = new AllowedMentions();
+            await wb.SendAsync(msg);
         }
     }
 }


### PR DESCRIPTION
Implement https://discord.com/developers/docs/resources/channel#allowed-mentions-object so that mentions can be disabled for a message.

My use case is sending game server chat logs to a channel and sometimes someone types "@everyone" into ingame chat, causing a Discord notification to be triggered.